### PR TITLE
Add 'grounded' option

### DIFF
--- a/scsnowman-normal.def
+++ b/scsnowman-normal.def
@@ -12,7 +12,13 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{scsnowman-normal.def}[2016/12/22 v1.0 scsnowman definition (normal)]
 \def\sctkzsym@snowman@normal{%
-  \begin{tikzpicture}[x=1.8ex,y=1.8ex,line width=0.025ex*\sctkzsym@coord@scl,line join=round,line cap=round,scale=\sctkzsym@snowman@scale]
+  \setlength{\sctkzsym@coord@baseline}{%
+    \ifsctkzsym@snowman@grounded
+      \dimexpr0.144ex*\sctkzsym@snowman@scale\relax
+    \else
+      \z@
+    \fi}%
+  \begin{tikzpicture}[x=1.8ex,y=1.8ex,line width=0.025ex*\sctkzsym@coord@scl,line join=round,line cap=round,scale=\sctkzsym@snowman@scale,baseline=\sctkzsym@coord@baseline]
     \useasboundingbox(0,0) rectangle (1,1);
       \sctkzsym@snowman@bodypath % body (IPA-like)
         (0.5,0.72) .. controls (0.64,0.72) and (0.76,0.65) ..

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -116,6 +116,7 @@
   \def\sctkzsym@snowman@muffler{false}%
   \def\sctkzsym@snowman@buttons{false}%
   \def\sctkzsym@snowman@snow{false}%
+  \def\sctkzsym@snowman@grounded{false}%
 }
 \newcommand{\sctkzsym@snowman@defaultkeys}{%
   \sctkzsym@snowman@initkeys
@@ -135,6 +136,7 @@
 \sctkzsym@define@key@withbool{snowman}{muffler}
 \sctkzsym@define@key@withbool{snowman}{buttons}
 \sctkzsym@define@key@withbool{snowman}{snow}
+\sctkzsym@define@key@withbool{snowman}{grounded}
 %
 % count definitions for \sctkzsym@hndl@key@wodefault
 \newcount\sctkzsym@snowman@mouthshape@c
@@ -213,6 +215,8 @@
   \def\sctkzsym@snowman@buttonpath{\path[draw=\sctkzsym@snowman@buttonstroke,fill=\sctkzsym@snowman@buttonfill]}%
   % check snow
   \sctkzsym@hndl@key@withbool{snowman}{snow}%
+  % check grounded
+  \sctkzsym@hndl@key@withbool{snowman}{grounded}%
   %
   % drawing snowman
   \set@sctkzsym@coord@scl{\sctkzsym@snowman@scale}%

--- a/sctkzsym-base.sty
+++ b/sctkzsym-base.sty
@@ -110,6 +110,7 @@
 }
 %
 % setup for tikzpicture
+\newlength{\sctkzsym@coord@baseline}
 \newlength{\sctkzsym@coord@scl}
 \newcommand*{\set@sctkzsym@coord@scl}[1]{\pgfmathsetlength{\sctkzsym@coord@scl}{#1pt}}
 \newcommand{\sctkzsym@defaultcolor}{black}


### PR DESCRIPTION
今日から弊社で常用を始めてみたところ，早速ユーザから「`\scsnowman` をインラインで使うと，`scale` オプションで大きくするにつれてゆきだるまがどんどん上に浮いてしまうように見える」という意見が寄せられました。そこで，ゆきだるまの最下部が外側のベースラインと一致するようにするオプションを `grounded` という名前で追加してみました。ご参考まで。

## デフォルト

![2017-01-20 15 14 58](https://cloud.githubusercontent.com/assets/6186180/22138314/47fb8d80-df23-11e6-905e-9d6a0170ade8.png)


## `grounded` オプション有効

![2017-01-20 15 15 11](https://cloud.githubusercontent.com/assets/6186180/22138318/4b54cfd2-df23-11e6-80db-99bdbbb9ef81.png)
