### PR TITLE
enumerate環境でも\itemにゆきだるまを

### DIFF
--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -18,16 +18,16 @@
 % change enumerate label (joke)
 \def\enusnowman{%
 \@ifnextchar[%
-\sctkzsym@snowman%
-\sctkzsym@@snowman%
+\sctkzsym@enusnowman%
+\sctkzsym@@enusnowman%
 }%
-\def\sctkzsym@snowman[#1]#2{%
+\def\sctkzsym@enusnowman[#1]#2{%
 \def\sctkzsym@snowmannumeralscsnowman{%
 \scsnowman[#1]}%
 \expandafter\sctkzsym@@@snowmannumeral\expandafter{%
 \csname c@#2\endcsname}%
 }%
-\def\sctkzsym@@snowman#1{%
+\def\sctkzsym@@enusnowman#1{%
 \expandafter\sctkzsym@@snowmannumeral\expandafter{%
 \csname c@#1\endcsname}%
 }%

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -15,6 +15,55 @@
 \ProcessOptions\relax
 \RequirePackage{sctkzsym-base}[2017/08/08]
 %
+% change enumerate label (joke)
+\def\enusnowman{%
+\@ifnextchar[%
+\sctkzsym@snowman%
+\sctkzsym@@snowman%
+}%
+\def\sctkzsym@snowman[#1]#2{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[#1]}%
+\expandafter\sctkzsym@@@snowmannumeral\expandafter{%
+\csname c@#2\endcsname}%
+}%
+\def\sctkzsym@@snowman#1{%
+\expandafter\sctkzsym@@snowmannumeral\expandafter{%
+\csname c@#1\endcsname}%
+}%
+%
+% change 8 to snowman in counters
+\def\sctkzsym@snowmannumeralscsnowman{\relax}
+\def\sctkzsym@snowmannumeralinterval{\relax}
+\def\scsnowmannumeral{%
+\@ifnextchar[%
+\sctkzsym@snowmannumeral%
+\sctkzsym@@snowmannumeral%
+}%
+\def\sctkzsym@snowmannumeral[#1]#2{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[#1]}%
+\sctkzsym@@@snowmannumeral{#2}%
+}%
+\def\sctkzsym@@snowmannumeral#1{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[]}%
+\sctkzsym@@@snowmannumeral{#1}%
+}%
+\def\sctkzsym@@@snowmannumeral#1{%
+\expandafter\sctkzsym@snowmannumeralhead\number#18\sctkzsym@snowmannumeralinterval\sctkzsym@snowmannumeraltail}%
+\def\sctkzsym@snowmannumeralhead#18#2\sctkzsym@snowmannumeraltail{%
+\bgroup\def\sctkzsym@@snowmannumeralinterval{#2}%
+\edef\@tempa{\sctkzsym@snowmannumeralinterval}%
+\edef\@tempb{\sctkzsym@@snowmannumeralinterval}%
+\ifx\@tempa\@tempb%
+#1%
+\else%
+#1\sctkzsym@snowmannumeralscsnowman%
+\sctkzsym@snowmannumeralhead#2\sctkzsym@snowmannumeraltail%
+\fi\egroup%
+}%
+%
 % make document snowman (joke)
 \ifsctkzsym@document
 \def\makedocumentsnowman{%

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -15,55 +15,6 @@
 \ProcessOptions\relax
 \RequirePackage{sctkzsym-base}[2017/08/08]
 %
-% change enumerate label (joke)
-\def\enusnowman{%
-\@ifnextchar[%
-\sctkzsym@enusnowman%
-\sctkzsym@@enusnowman%
-}%
-\def\sctkzsym@enusnowman[#1]#2{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[#1]}%
-\expandafter\sctkzsym@@@snowmannumeral\expandafter{%
-\csname c@#2\endcsname}%
-}%
-\def\sctkzsym@@enusnowman#1{%
-\expandafter\sctkzsym@@snowmannumeral\expandafter{%
-\csname c@#1\endcsname}%
-}%
-%
-% change 8 to snowman in counters
-\def\sctkzsym@snowmannumeralscsnowman{\relax}
-\def\sctkzsym@snowmannumeralinterval{\relax}
-\def\scsnowmannumeral{%
-\@ifnextchar[%
-\sctkzsym@snowmannumeral%
-\sctkzsym@@snowmannumeral%
-}%
-\def\sctkzsym@snowmannumeral[#1]#2{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[#1]}%
-\sctkzsym@@@snowmannumeral{#2}%
-}%
-\def\sctkzsym@@snowmannumeral#1{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[]}%
-\sctkzsym@@@snowmannumeral{#1}%
-}%
-\def\sctkzsym@@@snowmannumeral#1{%
-\expandafter\sctkzsym@snowmannumeralhead\number#18\sctkzsym@snowmannumeralinterval\sctkzsym@snowmannumeraltail}%
-\def\sctkzsym@snowmannumeralhead#18#2\sctkzsym@snowmannumeraltail{%
-\bgroup\def\sctkzsym@@snowmannumeralinterval{#2}%
-\edef\@tempa{\sctkzsym@snowmannumeralinterval}%
-\edef\@tempb{\sctkzsym@@snowmannumeralinterval}%
-\ifx\@tempa\@tempb%
-#1%
-\else%
-#1\sctkzsym@snowmannumeralscsnowman%
-\sctkzsym@snowmannumeralhead#2\sctkzsym@snowmannumeraltail%
-\fi\egroup%
-}%
-%
 % make document snowman (joke)
 \ifsctkzsym@document
 \def\makedocumentsnowman{%
@@ -150,6 +101,55 @@
     \fi
   }
 \fi
+%
+% change enumerate label (joke)
+\def\enusnowman{%
+\@ifnextchar[%
+\sctkzsym@enusnowman%
+\sctkzsym@@enusnowman%
+}%
+\def\sctkzsym@enusnowman[#1]#2{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[#1]}%
+\expandafter\sctkzsym@@@snowmannumeral\expandafter{%
+\csname c@#2\endcsname}%
+}%
+\def\sctkzsym@@enusnowman#1{%
+\expandafter\sctkzsym@@snowmannumeral\expandafter{%
+\csname c@#1\endcsname}%
+}%
+%
+% change 8 to snowman in counters
+\def\sctkzsym@snowmannumeralscsnowman{\relax}
+\def\sctkzsym@snowmannumeralinterval{\relax}
+\def\scsnowmannumeral{%
+\@ifnextchar[%
+\sctkzsym@snowmannumeral%
+\sctkzsym@@snowmannumeral%
+}%
+\def\sctkzsym@snowmannumeral[#1]#2{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[#1]}%
+\sctkzsym@@@snowmannumeral{#2}%
+}%
+\def\sctkzsym@@snowmannumeral#1{%
+\def\sctkzsym@snowmannumeralscsnowman{%
+\scsnowman[]}%
+\sctkzsym@@@snowmannumeral{#1}%
+}%
+\def\sctkzsym@@@snowmannumeral#1{%
+\expandafter\sctkzsym@snowmannumeralhead\number#18\sctkzsym@snowmannumeralinterval\sctkzsym@snowmannumeraltail}%
+\def\sctkzsym@snowmannumeralhead#18#2\sctkzsym@snowmannumeraltail{%
+\bgroup\def\sctkzsym@@snowmannumeralinterval{#2}%
+\edef\@tempa{\sctkzsym@snowmannumeralinterval}%
+\edef\@tempb{\sctkzsym@@snowmannumeralinterval}%
+\ifx\@tempa\@tempb%
+#1%
+\else%
+#1\sctkzsym@snowmannumeralscsnowman%
+\sctkzsym@snowmannumeralhead#2\sctkzsym@snowmannumeraltail%
+\fi\egroup%
+}%
 %
 % key initialization
 \newcommand\sctkzsym@snowman@initkeys{%

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -105,7 +105,7 @@
 % change enumerate label using \scsnowmannumeral (joke)
 % (this feature is `scsnowman'-specific, so the name-space
 %  is intentionally set to \scsnowman@...)
-\def\enusnowman{%
+\DeclareRobustCommand{\enusnowman}{%
   \@ifnextchar[%
     {\scsnowman@enumsnowman}%
     {\scsnowman@enumsnowman[]}%

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -102,54 +102,50 @@
   }
 \fi
 %
-% change enumerate label (joke)
+% change enumerate label using \scsnowmannumeral (joke)
+% (this feature is `scsnowman'-specific, so the name-space
+%  is intentionally set to \scsnowman@...)
 \def\enusnowman{%
-\@ifnextchar[%
-\sctkzsym@enusnowman%
-\sctkzsym@@enusnowman%
-}%
-\def\sctkzsym@enusnowman[#1]#2{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[#1]}%
-\expandafter\sctkzsym@@@snowmannumeral\expandafter{%
-\csname c@#2\endcsname}%
-}%
-\def\sctkzsym@@enusnowman#1{%
-\expandafter\sctkzsym@@snowmannumeral\expandafter{%
-\csname c@#1\endcsname}%
-}%
+  \@ifnextchar[%
+    {\scsnowman@enumsnowman}%
+    {\scsnowman@enumsnowman[]}%
+}
+\def\scsnowman@enumsnowman[#1]#2{%
+  \def\scsnowman@eight{\scsnowman[#1]}%
+  \expandafter\scsnowman@@numeral\expandafter{%
+    \csname c@#2\endcsname}%
+}
 %
-% change 8 to snowman in counters
-\def\sctkzsym@snowmannumeralscsnowman{\relax}
-\def\sctkzsym@snowmannumeralinterval{\relax}
+% change 8 to snowman in counters (joke)
+% (this feature is `scsnowman'-specific, so the name-space
+%  is intentionally set to \scsnowman@...)
+\def\scsnowman@numeral@interval{\relax}
 \def\scsnowmannumeral{%
-\@ifnextchar[%
-\sctkzsym@snowmannumeral%
-\sctkzsym@@snowmannumeral%
-}%
-\def\sctkzsym@snowmannumeral[#1]#2{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[#1]}%
-\sctkzsym@@@snowmannumeral{#2}%
-}%
-\def\sctkzsym@@snowmannumeral#1{%
-\def\sctkzsym@snowmannumeralscsnowman{%
-\scsnowman[]}%
-\sctkzsym@@@snowmannumeral{#1}%
-}%
-\def\sctkzsym@@@snowmannumeral#1{%
-\expandafter\sctkzsym@snowmannumeralhead\number#18\sctkzsym@snowmannumeralinterval\sctkzsym@snowmannumeraltail}%
-\def\sctkzsym@snowmannumeralhead#18#2\sctkzsym@snowmannumeraltail{%
-\bgroup\def\sctkzsym@@snowmannumeralinterval{#2}%
-\edef\@tempa{\sctkzsym@snowmannumeralinterval}%
-\edef\@tempb{\sctkzsym@@snowmannumeralinterval}%
-\ifx\@tempa\@tempb%
-#1%
-\else%
-#1\sctkzsym@snowmannumeralscsnowman%
-\sctkzsym@snowmannumeralhead#2\sctkzsym@snowmannumeraltail%
-\fi\egroup%
-}%
+  \@ifnextchar[%
+    {\scsnowman@numeral}%
+    {\scsnowman@numeral[]}%
+}
+\def\scsnowman@numeral[#1]#2{%
+  \def\scsnowman@eight{\scsnowman[#1]}%
+  \scsnowman@@numeral{#2}%
+}
+\def\scsnowman@@numeral#1{%
+  \expandafter\scsnowman@numeral@head
+    \number#18\scsnowman@numeral@interval
+    \scsnowman@numeral@tail}%
+\def\scsnowman@numeral@head#18#2\scsnowman@numeral@tail{%
+  \bgroup
+    \def\scsnowman@@numeral@interval{#2}%
+    \edef\@tempa{\scsnowman@numeral@interval}%
+    \edef\@tempb{\scsnowman@@numeral@interval}%
+    \ifx\@tempa\@tempb
+      #1%
+    \else
+      #1\scsnowman@eight
+      \scsnowman@numeral@head#2\scsnowman@numeral@tail
+    \fi
+  \egroup
+}
 %
 % key initialization
 \newcommand\sctkzsym@snowman@initkeys{%


### PR DESCRIPTION
はじめてのPull Requestなのでやり方など間違っていたらごめんなさい。

enumerate環境中でも`\item`にゆきだるまが欲しくなり，`\enusnowman`を作りました。`\roman`や`\arabic`といった命令と同様，`\renewcommand{\labelenumi}{\enusnowman{enumi}}`で数字の8だけがゆきだるま化します。

ついでに，
`\scsnowmannumeral`（`\romannumeral`と同等の用法）を実装。http://ut-tex.org/pdf/week8macro.pdf にも説明を載せました。

なお，オプション引数もそのまま使えます。

（今気づいたのですが

`\enusnowman`という名前で作ってしまいましたが，scを入れて`\enuscsnowman`とかの方が良かったでしょうか……。）