### PR TITLE
add 'santa hat' option

### DIFF
--- a/scsnowman-normal.def
+++ b/scsnowman-normal.def
@@ -78,6 +78,9 @@
     \fi
     \fi
     \ifsctkzsym@snowman@santa
+      %%% Reference(Japanese only):
+      %%% https://puripuri2100.hatenablog.com/entry/2018/12/25/000805
+      %%% https://gist.github.com/puripuri2100/3290dd78ad7387b4bc30c61d1bb84df5
       \sctkzsym@snowman@santa@hatpath % santa
         (0.35,0.72) .. controls (0.35,0.72) and (0.35,0.88) ..
         (0.50,0.88) .. controls (0.50,0.88) and (0.525,0.88) ..

--- a/scsnowman-normal.def
+++ b/scsnowman-normal.def
@@ -77,6 +77,29 @@
         cycle;
     \fi
     \fi
+    \ifsctkzsym@snowman@santa
+      \sctkzsym@snowman@santa@hatpath % santa
+        (0.35,0.72) .. controls (0.35,0.72) and (0.35,0.88) ..
+        (0.50,0.88) .. controls (0.50,0.88) and (0.525,0.88) ..
+        (0.58,0.88) .. controls (0.58,0.88) and (0.70,0.88) ..
+        (0.73,0.82) .. controls (0.73,0.82) and (0.73,0.82) ..
+        (0.72,0.81) .. controls (0.72,0.81) and (0.66,0.85) ..
+        (0.61,0.83) .. controls (0.61,0.83) and (0.66,0.78) ..
+        (0.65,0.72) .. controls (0.65,0.72) and (0.50,0.72) ..
+        (0.35,0.72) --
+        cycle;
+    \sctkzsym@snowman@santa@furpath % santa
+      (0.74,0.81) circle [radius=0.02];
+    \sctkzsym@snowman@santa@furpath % santa
+      (0.35,0.67) .. controls (0.35,0.67) and (0.32,0.675) ..
+      (0.32,0.70) .. controls (0.32,0.70) and (0.32,0.725) ..
+      (0.35,0.73) .. controls (0.35,0.73) and (0.50,0.74) ..
+      (0.65,0.73) .. controls (0.65,0.73) and (0.68,0.725) ..
+      (0.68,0.70) .. controls (0.68,0.70) and (0.68,0.675) ..
+      (0.65,0.67) .. controls (0.65,0.67) and (0.50,0.66) ..
+      (0.35,0.67) --
+      cycle;
+    \fi
     \ifsctkzsym@snowman@broom
       \sctkzsym@snowman@broompath[line width=0.08ex*\sctkzsym@coord@scl,line cap=butt]
         (0.03,0.06) -- (0.12,0.50);

--- a/scsnowman.sty
+++ b/scsnowman.sty
@@ -204,6 +204,7 @@
   \def\sctkzsym@snowman@adjustbaseline{false}%
   \def\sctkzsym@snowman@mikan{false}%
   \def\sctkzsym@snowman@leaf{false}%
+  \def\sctkzsym@snowman@santa{false}%
   \def\sctkzsym@snowman@broom{false}%
 }
 \newcommand{\sctkzsym@snowman@defaultkeys}{%
@@ -230,6 +231,7 @@
 \sctkzsym@define@key@withbool{snowman}{adjustbaseline}
 \sctkzsym@define@key@withbool{snowman}{mikan}
 \sctkzsym@define@key@withbool{snowman}{leaf}
+\sctkzsym@define@key@withbool{snowman}{santa}
 \sctkzsym@define@key@withbool{snowman}{broom}
 %
 % definition of \scsnowman[...]
@@ -340,6 +342,14 @@
   \def\sctkzsym@snowman@leaffill{\sctkzsym@snowman@leaf}%
   \def\sctkzsym@snowman@leafpath
     {\path[draw=\sctkzsym@snowman@leafstroke,fill=\sctkzsym@snowman@leaffill]}%
+  % check santa
+  \sctkzsym@hndl@key@withbool{snowman}{santa}%
+  \def\sctkzsym@snowman@santafill{\sctkzsym@snowman@santa}%
+  \def\sctkzsym@snowman@santastroke{\sctkzsym@defaultcolor}%
+  \def\sctkzsym@snowman@santa@hatpath
+    {\path[draw=\sctkzsym@snowman@santastroke,fill=\sctkzsym@snowman@santafill]}%
+  \def\sctkzsym@snowman@santa@furpath
+    {\path[draw=\sctkzsym@snowman@santastroke,fill=white]}%
   % check broom (only stroke)
   \sctkzsym@hndl@key@withbool{snowman}{broom}%
   \def\sctkzsym@snowman@broomstroke{\sctkzsym@snowman@broom}%

--- a/scsnowman.tex
+++ b/scsnowman.tex
@@ -419,7 +419,7 @@ Following \emph{key} is implemented for this usage:
   \Lopt{santa}
 \end{quote}
 
-Here is an example:\\[1ex]
+Here are some examples:\\[1ex]
 \begin{minipage}{.75\textwidth}\begin{verbatim}
   \scsnowmandefault{scale=5.5}
   \scsnowman[santa]

--- a/scsnowman.tex
+++ b/scsnowman.tex
@@ -410,6 +410,26 @@ Here is an example:\\[1ex]
   \scsnowman[eyes=false,mouth=false,mikan=orange,leaf=green]
 \end{minipage}
 
+\subsection{Drawing ``\emph{Santa hat}''}
+
+Using \Lpack{scsnowman} package, you can also draw ``\emph{santa hat}''.
+
+Following \emph{key} is implemented for this usage:
+\begin{quote}
+  \Lopt{santa}
+\end{quote}
+
+Here is an example:\\[1ex]
+\begin{minipage}{.75\textwidth}\begin{verbatim}
+  \scsnowmandefault{scale=5.5}
+  \scsnowman[santa]
+  {\color{blue}\scsnowman[santa=red]}
+\end{verbatim}\end{minipage}
+\begin{minipage}{.2\textwidth}
+  \scsnowmandefault{scale=5.5}
+  \scsnowman[santa]{\color{blue}\scsnowman[santa=red]}
+\end{minipage}
+
 \subsection{Replacing All ``8'' with Snowmen}
 
 You can replace all ``8'' inside an arabic number expression with snowmen


### PR DESCRIPTION
昔に描いた雪だるま用サンタ帽[^1][^2]をscsnowmanに移植しました。
[^1]: https://puripuri2100.hatenablog.com/entry/2018/12/25/000805
[^2]: https://gist.github.com/puripuri2100/3290dd78ad7387b4bc30c61d1bb84df5

出力結果はこのようになります。

<img width="1067" alt="雪だるま用サンタ帽" src="https://user-images.githubusercontent.com/36466996/147589741-1d385617-59df-4814-a6a1-875ee39b6311.png">



ドキュメントには見よう見まねで記述を追加してみました。修正するべき点等ありましたら指摘していただければすぐに修正します。

